### PR TITLE
Bugfix/shrunken new

### DIFF
--- a/spacells/tests/_getBoundary.py
+++ b/spacells/tests/_getBoundary.py
@@ -31,7 +31,7 @@ def getBoundary(anndata,
     # print("edge_components:", len(edge_components), [len(i) for i in edge_components], edge_components[0].shape)
     
     grouped_components = groupRemoveEdgeComponents(edge_components, nedges_min, nedges_out_min)
-
+    return grouped_components
     boundary_edges = getEdgesOnBoundary(grouped_components)
     
     return boundary_edges

--- a/spacells/tests/_getShrunkenBoundary.py
+++ b/spacells/tests/_getShrunkenBoundary.py
@@ -1,35 +1,35 @@
 import numpy as np
-import math
+from shapely.geometry import Polygon, MultiPolygon
 from _utils import *
 
-def getShrunkenBoundary(boundary, offset=200, alpha=100, minsize=30):
+def getExtendedBoundary(boundaries, offset=200, minsize=30):
+    return getBufferedBoundary(boundaries, offset, minsize)
 
-    # print("get points on edges")
-    boundary_points = boundary[:,0,:]
+def getShrunkenBoundary(boundaries, offset=200, minsize=30):
+    return getBufferedBoundary(boundaries, -offset, minsize)
 
-    # print("get stretched points")
-    pointsStretched = bufferPoints(boundary_points, offset, n=100)
-
-    # print("get edge_components of stretched points")
-    edge_components = getAlphaShapes(pointsStretched, alpha)
-    # print("edge_components:", len(edge_components), 
-    #     [len(comp) for comp in edge_components])
-
-    shrunken_boundaries = []
-    for comp in edge_components:
-        keep = True
-        # print(len(comp))
-        for i in range(len(comp)):
-            if len(comp) < minsize:
-                keep = False
-                break
-            point = comp[i][0]
-            if not isInRegion(point, boundary):
-                # print("out", point)
-                keep = False
-                break
-        if keep:
-            shrunken_boundaries.append(comp)
-    return np.concatenate(shrunken_boundaries)
-
-
+def getBufferedBoundary(boundaries, offset=200, minsize=30):
+    buffered_boundaries = []
+    outer_multipolygon = Polygon()
+    inner_multipolygon = Polygon()
+    for boundary_set in boundaries:
+        for i, boundary in enumerate(boundary_set):
+            boundary_points = boundary[:, 0, :]
+            boundary_polygon = Polygon(boundary_points)
+            if i == 0:
+                outer_multipolygon = outer_multipolygon | boundary_polygon.buffer(-offset)
+            else:
+                inner_multipolygon = inner_multipolygon | boundary_polygon.buffer(offset)
+    s_boundary_polygons = outer_multipolygon - inner_multipolygon
+    if isinstance(s_boundary_polygons, MultiPolygon):
+        s_boundary_polygons = s_boundary_polygons.geoms
+    else:
+        s_boundary_polygons = [s_boundary_polygons]
+    for s_boundary_polygon in s_boundary_polygons:
+        for ring in [s_boundary_polygon.exterior] + list(s_boundary_polygon.interiors):
+            buffered_points = np.array(ring.coords)
+            if buffered_points.shape[0] < minsize:
+                continue
+            buffered_edges = np.stack([np.roll(buffered_points, -1, axis=0), buffered_points], axis=1)
+            buffered_boundaries.append(buffered_edges)
+    return [buffered_boundaries]

--- a/spacells/tests/_getShrunkenBoundary.py
+++ b/spacells/tests/_getShrunkenBoundary.py
@@ -17,9 +17,9 @@ def getBufferedBoundary(boundaries, offset=200, minsize=30):
             boundary_points = boundary[:, 0, :]
             boundary_polygon = Polygon(boundary_points)
             if i == 0:
-                outer_multipolygon = outer_multipolygon | boundary_polygon.buffer(-offset)
+                outer_multipolygon = outer_multipolygon | boundary_polygon.buffer(offset)
             else:
-                inner_multipolygon = inner_multipolygon | boundary_polygon.buffer(offset)
+                inner_multipolygon = inner_multipolygon | boundary_polygon.buffer(-offset)
     s_boundary_polygons = outer_multipolygon - inner_multipolygon
     if isinstance(s_boundary_polygons, MultiPolygon):
         s_boundary_polygons = s_boundary_polygons.geoms


### PR DESCRIPTION
Update getShrunkenBoundaries and getExpandedBoundaries to use Shapely for efficient processing and fixing of erratic behaviours
New implementation takes about 1s for any offset
Add logic to merge new boundaries correctly

Old: 
<img width="500" alt="image" src="https://github.com/SemenovLab/SpatialCells/assets/38070760/4eeb8254-b6f8-4742-b55a-50b44473ace6">

New:
<img width="500" alt="image" src="https://github.com/SemenovLab/SpatialCells/assets/38070760/36bf5003-979f-45aa-9a17-51bf05a25ba2">

